### PR TITLE
Support binding via ngModel

### DIFF
--- a/chosen.js
+++ b/chosen.js
@@ -53,13 +53,20 @@
           };
           $timeout(function() {
             var chosen = element.chosen(options);
-            element.val(ngModel.$viewValue || '').trigger("liszt:updated");
+            if (ngModel)
+            {
+              element.val(ngModel.$viewValue || '').trigger("liszt:updated");  
+            }
+            
             return chosen;
           });
           
-          ngModel.$render = function() {
-            element.val(ngModel.$viewValue || '').trigger("liszt:updated");
-          };
+          if (ngModel)
+          {
+            ngModel.$render = function() {
+              element.val(ngModel.$viewValue || '').trigger("liszt:updated");
+            };
+          }
           
           if (attr.ngOptions) {
             match = attr.ngOptions.match(NG_OPTIONS_REGEXP);


### PR DESCRIPTION
Current implementation of the directive does not honor ngModel being able to update the view.  This is also preventing the initial value from being set via the controller.

To illustrate:

``` html
<select class="span2" chosen ng-model="params.StateCd">
   <option></option>
   <option ng-repeat="state in statelist" value="{{state.StateCd}}">{{state.StateName}}</option>
</select>
```

The chosen select box does not populate the value of params.StateCd when it's updated via the scope.  I've updated the directive to require ngModel, set the value, and fire the chosen liszt:updated event when it's updated.  
