### PR TITLE
Use only one timeout for multiple chosen selects. Improves performance

### DIFF
--- a/chosen.js
+++ b/chosen.js
@@ -6,7 +6,7 @@
 
   angular.module('localytics.directives').directive('chosen', [
     '$timeout', function($timeout) {
-      var CHOSEN_OPTION_WHITELIST, NG_OPTIONS_REGEXP, chosen, isEmpty, snakeCase;
+      var CHOSEN_OPTION_WHITELIST, NG_OPTIONS_REGEXP, chosen, isEmpty, nextTick, snakeCase, todoNextTick;
       NG_OPTIONS_REGEXP = /^\s*(.*?)(?:\s+as\s+(.*?))?(?:\s+group\s+by\s+(.*))?\s+for\s+(?:([\$\w][\$\w]*)|(?:\(\s*([\$\w][\$\w]*)\s*,\s*([\$\w][\$\w]*)\s*\)))\s+in\s+(.*?)(?:\s+track\s+by\s+(.*?))?$/;
       CHOSEN_OPTION_WHITELIST = ['noResultsText', 'allowSingleDeselect', 'disableSearchThreshold', 'disableSearch', 'enableSplitWordSearch', 'inheritSelectClasses', 'maxSelectedOptions', 'placeholderTextMultiple', 'placeholderTextSingle', 'searchContains', 'singleBackstrokeDelete', 'displayDisabledOptions', 'displaySelectedOptions', 'width'];
       snakeCase = function(input) {
@@ -26,6 +26,18 @@
           }
         }
         return true;
+      };
+      todoNextTick = [];
+      nextTick = function(fn) {
+        if (todoNextTick.length === 0) {
+          $timeout(function() {
+            angular.forEach(todoNextTick, function(fn) {
+              return fn();
+            });
+            return todoNextTick = [];
+          });
+        }
+        return todoNextTick.push(fn);
       };
       return chosen = {
         restrict: 'A',
@@ -55,7 +67,7 @@
             empty = true;
             return element.empty().append("<option selected class=\"empty\">" + message + "</option>").attr('disabled', true).trigger('chosen:updated');
           };
-          $timeout(function() {
+          nextTick(function() {
             return element.chosen(options);
           });
           if (ctrl) {

--- a/src/chosen.coffee
+++ b/src/chosen.coffee
@@ -31,6 +31,14 @@ angular.module('localytics.directives').directive 'chosen', ['$timeout', ($timeo
       return false for key of value when value.hasOwnProperty(key)
     true
 
+  todoNextTick = []
+  nextTick = (fn) ->
+    if todoNextTick.length == 0
+      $timeout ->
+        angular.forEach todoNextTick, (fn) -> fn()
+        todoNextTick = []
+    todoNextTick.push(fn)
+
   chosen =
     restrict: 'A'
     require: '?ngModel'
@@ -38,7 +46,7 @@ angular.module('localytics.directives').directive 'chosen', ['$timeout', ($timeo
     link: (scope, element, attr, ctrl) ->
 
       element.addClass('localytics-chosen')
-      
+
       # Take a hash of options from the chosen directive
       options = scope.$eval(attr.chosen) or {}
 
@@ -60,7 +68,7 @@ angular.module('localytics.directives').directive 'chosen', ['$timeout', ($timeo
         element.empty().append("""<option selected class="empty">#{message}</option>""").attr('disabled', true).trigger('chosen:updated')
 
       # Init chosen on the next loop so ng-options can populate the select
-      $timeout -> element.chosen options
+      nextTick -> element.chosen options
 
       #Watch the underlying ng-model for updates and trigger an update when they occur.
       if ctrl


### PR DESCRIPTION
If multiple chosen directives are added in a single page, all the chosen initializations take a separate timeout to execute. This is inefficient when having a bunch of them.

This PR makes them all use a single timeout tick to initialize them.
