### PR TITLE
Use compiled JS zip for chosen

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "example"
   ],
   "dependencies": {
-    "chosen": "~1.0.0",
+    "chosen": "https://github.com/harvesthq/chosen/releases/download/1.0.0/chosen_v1.0.0.zip",
     "angular": ">=1.2.0"
   }
 }


### PR DESCRIPTION
Chosen has decided not to package compiled JS in their usual bower version. @slobo [recommended](https://github.com/slobo/angular-chosen/pull/1) me to make a PR on the main repo recently to use their production zip that does contain compiled JS.

This change will enable bower users to use this directive without  hiccups.
