### PR TITLE
Throws exception at mobile

### DIFF
--- a/src/chosen.coffee
+++ b/src/chosen.coffee
@@ -57,7 +57,9 @@ angular.module('localytics.directives').directive 'chosen', ->
         element.trigger('chosen:updated')
       else
         chosen = element.chosen(options).data('chosen')
-        defaultText = chosen.default_text
+        if angular.isObject(chosen) {
+          defaultText = chosen.default_text
+        }
 
     # Use Chosen's placeholder or no results found text depending on whether there are options available
     removeEmptyMessage = ->


### PR DESCRIPTION
Chosen doesn't return undefined at mobile
for element.chosen(options).data('chosen')
So chosen.default_text will trigger an error
