### PR TITLE
Replace chosen with chosen-build

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "example"
   ],
   "dependencies": {
-    "chosen": "https://github.com/harvesthq/chosen/releases/download/1.0.0/chosen_v1.0.0.zip",
+    "chosen-build": "https://github.com/mvrkljan/chosen-build",
     "angular": ">=1.2.0"
   }
 }


### PR DESCRIPTION
Chosen-build has a bower.json file that includes a main attribute with the correct file names. This allows grunt-wiredep to work.
