### PR TITLE
add mobile choosen check code

### DIFF
--- a/chosen.js
+++ b/chosen.js
@@ -56,7 +56,9 @@
             return element.trigger('chosen:updated');
           } else {
             chosen = element.chosen(options).data('chosen');
-            return defaultText = chosen.default_text;
+            if (angular.isObject(chosen)) {
+              return defaultText = chosen.default_text;
+            }
           }
         };
         removeEmptyMessage = function() {

--- a/src/chosen.coffee
+++ b/src/chosen.coffee
@@ -57,7 +57,8 @@ angular.module('localytics.directives').directive 'chosen', ->
         element.trigger('chosen:updated')
       else
         chosen = element.chosen(options).data('chosen')
-        defaultText = chosen.default_text
+        if angular.isObject(chosen)
+          defaultText = chosen.default_text
 
     # Use Chosen's placeholder or no results found text depending on whether there are options available
     removeEmptyMessage = ->


### PR DESCRIPTION
Chosen doesn't return undefined at mobile
for element.chosen(options).data('chosen')
So chosen.default_text will trigger an error
You can also see my comment there https://github.com/localytics/angular-chosen/issues/69