### PR TITLE
adding scope.$$postDigest() to stopLoading and disableWithMessage functi...

### DIFF
--- a/src/chosen.coffee
+++ b/src/chosen.coffee
@@ -100,5 +100,5 @@ angular.module('localytics.directives').directive 'chosen', ->
           startLoading()
         else
           removeEmptyMessage() if empty
-          stopLoading()
-          disableWithMessage() if isEmpty(newVal)
+          scope.$$postDigest(stopLoading)
+          scope.$$postDigest(disableWithMessage) if isEmpty(newVal)


### PR DESCRIPTION
Adding scope.$$postDigest() to stopLoading and disableWithMessage functions in order to guarantee they are called after angular has completed its dirty checking of the DOM.This fix is required for compatibility with AngularJS >=1.3.0. Without it, the chosen select does not render the data.