### PR TITLE
Fix ng-disabled being ignored in stopLoading

### DIFF
--- a/src/chosen.coffee
+++ b/src/chosen.coffee
@@ -46,7 +46,7 @@ angular.module('localytics.directives').directive 'chosen', ['$timeout', ($timeo
       options[snakeCase(key)] = scope.$eval(value) if key in CHOSEN_OPTION_WHITELIST
 
     startLoading = -> element.addClass('loading').attr('disabled', true).trigger('chosen:updated')
-    stopLoading = -> element.removeClass('loading').attr('disabled', false).trigger('chosen:updated')
+    stopLoading = -> element.removeClass('loading').attr('disabled', !!scope.$eval(attr.ngDisabled)).trigger('chosen:updated')
 
     chosen = null
     defaultText = null


### PR DESCRIPTION
Take ng-disabled into account when re-enabling the dropdown in stopLoading - otherwise, the dropdown ends up enabled.