### PR TITLE
Point Bower main attribute to non-minified version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "git://github.com/leocaseiro/angular-chosen.git"
   },
-  "main": "dist/angular-chosen.min.js",
+  "main": "dist/angular-chosen.js",
   "dependencies": {
     "jquery": "^2.0.3",
     "chosen": "^1.1.0",


### PR DESCRIPTION
Bower main attribute shouldn't point to minified version.

Bower recommends not to add minified files at all, actually:
https://github.com/bower/spec/blob/master/json.md
>Do not include minified files.