### PR TITLE
Remove deprecated version key from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "angular-chosen-localytics",
-  "version": "1.3.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/leocaseiro/angular-chosen.git"


### PR DESCRIPTION
See https://github.com/bower/spec/blob/master/json.md#version

Now that version is out of sync with actually tagged version, getting this when installing:
```
bower mismatch      Version declared in the json (1.3.0) is different than the resolved one (1.4.0)
bower resolved      https://github.com/leocaseiro/angular-chosen.git#1.4.0
```