### PR TITLE
Fix accidental shadowing of the chosen variable

### DIFF
--- a/src/chosen.coffee
+++ b/src/chosen.coffee
@@ -1,8 +1,8 @@
 angular.module('localytics.directives', [])
 
-chosen = angular.module('localytics.directives')
+chosenModule = angular.module('localytics.directives')
 
-chosen.provider 'chosen', ->
+chosenModule.provider 'chosen', ->
   options = {}
   {
     setOption: (newOpts) ->
@@ -12,7 +12,7 @@ chosen.provider 'chosen', ->
       options
   }
 
-chosen.directive 'chosen', ['chosen', '$timeout', (config, $timeout) ->
+chosenModule.directive 'chosen', ['chosen', '$timeout', (config, $timeout) ->
   # coffeelint: disable=max_line_length
   # This is stolen from Angular...
   NG_OPTIONS_REGEXP =  /^\s*([\s\S]+?)(?:\s+as\s+([\s\S]+?))?(?:\s+group\s+by\s+([\s\S]+?))?\s+for\s+(?:([\$\w][\$\w]*)|(?:\(\s*([\$\w][\$\w]*)\s*,\s*([\$\w][\$\w]*)\s*\)))\s+in\s+([\s\S]+?)(?:\s+track\s+by\s+([\s\S]+?))?$/


### PR DESCRIPTION
The `chosen` variable was accidentally being created as a module global. 

Looking at the compiled source, we have the variable being defined at the very beginning of the module:
https://github.com/leocaseiro/angular-chosen/blob/eef3db301ef887a8d84efade11371487e6ce68cc/dist/angular-chosen.js#L8

Afterwards, in the link function, it gets overwritten [here](https://github.com/leocaseiro/angular-chosen/blob/eef3db301ef887a8d84efade11371487e6ce68cc/dist/angular-chosen.js#L85) and [here](https://github.com/leocaseiro/angular-chosen/blob/eef3db301ef887a8d84efade11371487e6ce68cc/dist/angular-chosen.js#L97)

This is a huge issue, because it means that `initOrUpdate()` will sometimes erroneously not update existing chosen select boxes, but try to init itself.

Reproducing is a bit involved and I won't write out the complete source, but this should be enough to show how the error can happen:

```html
<select chosen ng-model="state" ng-options="s for s in states">
  <option value=""></option>
</select>

<button type="button" ng-click="addStateToList()">

<div ng-if="states.length">
  <select chosen ng-model="county">[...]</select>
</div>
```

```js
StateController($scope) {
  $scope.states = []
  $scope.addStateToList = function() {
    $scope.states.push($scope.state)
    $scope.state = null
  }
}
```

What will happen is, the first chosen select will not become empty on the very first addition of a state.

The reason is in the execution order. The function `addStateToList()` executes, what happens is the following:

 1. The `ng-if` directive triggers and the div is rendered by angular
 2. The link function of the second `chosen` executes. It [sets the module variable `chosen` to null](https://github.com/leocaseiro/angular-chosen/blob/eef3db301ef887a8d84efade11371487e6ce68cc/dist/angular-chosen.js#L85)
 3. NgModel rendering kicks in, and the first chosen's `initOrUpdate()` triggers.
 4. The first chosen [checks for the existence of the module variable `chosen`](https://github.com/leocaseiro/angular-chosen/blob/eef3db301ef887a8d84efade11371487e6ce68cc/dist/angular-chosen.js#L89), but that was nulled in 2)
 5. The first chosen does not trigger `chosen:updated` event, desyncing the angular model from the chosen display state.

----

While the bug and its explanation are somewhat involved, the fix is simple - make sure that the `chosen` variable inside the `link()` function is bound only to the particular chosen's link scope, and is not a global variable :)