### PR TITLE
Fix a potential $digest in progress error

### DIFF
--- a/src/chosen.coffee
+++ b/src/chosen.coffee
@@ -121,7 +121,7 @@ chosenModule.directive 'chosen', ['chosen', '$timeout', (config, $timeout) ->
         initOrUpdate()
 
       element.on 'chosen:hiding_dropdown', ->
-        scope.$apply -> ngModel.$setTouched()
+        scope.$applyAsync -> ngModel.$setTouched()
 
       # This is basically taken from angular ngOptions source.  ngModel watches reference, not value,
       # so when values are added or removed from array ngModels, $render won't be fired.

--- a/test/base.spec.js
+++ b/test/base.spec.js
@@ -8,7 +8,7 @@ describe('base functionality', function() {
 
     // Compile a piece of HTML containing the directive
     element = $compile('<select chosen ng-options="lang for lang in languages" ng-model="currentLanguage"><option></option></select>')($scope);
-    $scope.$digest();
+    $scope.$apply();
     $timeout.flush();
     element.trigger('chosen:open.chosen'); // fills dropdown (triggers chosen:showing_dropdown when finished)
     element.trigger('chosen:close.chosen');
@@ -33,7 +33,7 @@ describe('base functionality', function() {
     expect(chosenSelected.text()).toBe('german');
 
     $scope.currentLanguage = 'english';
-    $scope.$digest();
+    $scope.$apply();
 
     expect(chosenSelected.text()).toBe('english');
   });
@@ -43,7 +43,7 @@ describe('base functionality', function() {
 
     // Compile a piece of HTML containing the directive
     element = $compile('<select chosen ng-options="lang for lang in languages" ng-model="currentLanguage" ng-change="changed=true"><option></option></select>')($scope);
-    $scope.$digest();
+    $scope.$apply();
     $timeout.flush();
 
     element.trigger('chosen:open.chosen');
@@ -65,7 +65,7 @@ describe('base functionality', function() {
 
     // Compile a piece of HTML containing the directive
     element = $compile('<select chosen ng-options="lang for lang in languages" ng-model="currentLanguage" ng-disabled="disabled"><option></option></select>')($scope);
-    $scope.$digest();
+    $scope.$apply();
     $timeout.flush();
 
     var chosenContainer = element.next();
@@ -73,7 +73,7 @@ describe('base functionality', function() {
     expect(chosenContainer.hasClass('chosen-disabled')).toBe(true);
 
     $scope.disabled = false;
-    $scope.$digest();
+    $scope.$apply();
 
     expect(chosenContainer.hasClass('chosen-disabled')).toBe(false);
   });

--- a/test/chosenAttrSpec.js
+++ b/test/chosenAttrSpec.js
@@ -11,13 +11,13 @@ describe('chosen attributes', function() {
 
     //inherit-select-classes = true
     element = $compile(select(true, customClass))($scope);
-    $scope.$digest();
+    $scope.$apply();
     chosenContainer = element.next();
     expect(chosenContainer.hasClass(customClass)).toBe(true);
 
     //inherit-select-classes = false
     element = $compile(select(false, customClass))($scope);
-    $scope.$digest();
+    $scope.$apply();
     chosenContainer = element.next();
     expect(chosenContainer.hasClass(customClass)).toBe(false);
   });

--- a/test/form.spec.js
+++ b/test/form.spec.js
@@ -11,7 +11,7 @@ describe('form validations', function() {
     element = form.find('select');
     ngModel = $scope.form.language;
 
-    $scope.$digest();
+    $scope.$apply();
   });
 
   it('should work with required form validation', function() {
@@ -19,7 +19,7 @@ describe('form validations', function() {
     expect(ngModel.$error.required).toBe(true);
 
     $scope.currentLanguage = 'german';
-    $scope.$digest();
+    $scope.$apply();
 
     expect(ngModel.$valid).toBe(true);
   });
@@ -28,10 +28,10 @@ describe('form validations', function() {
     expect(ngModel.$touched).toBe(false);
 
     element.trigger('chosen:open.chosen');
-    $scope.$digest();
+    $scope.$apply();
 
     element.trigger('chosen:hiding_dropdown');
-    $scope.$digest();
+    $scope.$apply();
 
     expect(ngModel.$touched).toBe(true);
   });

--- a/test/issues/179-ng-if-breaks-inherit-select-classes.spec.js
+++ b/test/issues/179-ng-if-breaks-inherit-select-classes.spec.js
@@ -13,7 +13,7 @@ describe('#179 inherit-select-classes inside ng-if', function () {
 
     //inherit-select-classes = true
     element = $compile(select(true, customClass))($scope);
-    $scope.$digest();
+    $scope.$apply();
     chosenContainer = element.find('.localytics-directive').next();
     console.log('chosenContainer', element);
     $timeout(function() {

--- a/test/support/chosenSelectHelper.js
+++ b/test/support/chosenSelectHelper.js
@@ -19,7 +19,7 @@ angular.module('chosenSelectHelper', [])
       }
 
       $compile(this.selectTag)($scope);
-      $scope.$digest();
+      $scope.$apply();
       $timeout.flush();
     },
 


### PR DESCRIPTION
When the `chosen:hiding_dropdown` event triggers during a digest (ie, an
angular operation turns an open chosen into disabled with ng-disable,
which closes the dropdown) calling `$apply()` in the event call back triggers a
`$digest already in progress error`.

To fix that, we replace the call with `$applyAsync()`.

Additionally, we replace all instances of `$digest()` in the tests with
`$apply()`, because `$apply()` will also clear the async queue, and is the
preferred method of doing this over `$digest()`:
https://docs.angularjs.org/guide/unit-testing#testing-promises